### PR TITLE
update get context bash command

### DIFF
--- a/scripts/kgc.sh
+++ b/scripts/kgc.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 echo "{\"items\": ["
-contexts=`/usr/local/bin/kubectl config get-contexts | awk '{print $2}' | tail -n +2 | sort`
+contexts=`/usr/local/bin/kubectl config get-contexts --no-headers | sed  -e' s/|/ /' -e 's/^ *//' -e 's/^* *//' | awk '{print $1}' | tail -n +2 | sort`
 size=`echo $contexts | wc -w`
 current=`/usr/local/bin/kubectl config current-context`
 index=0

--- a/scripts/kgc.sh
+++ b/scripts/kgc.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 echo "{\"items\": ["
-contexts=`/usr/local/bin/kubectl config get-contexts --no-headers | sed  -e' s/|/ /' -e 's/^ *//' -e 's/^* *//' | awk '{print $1}' | tail -n +2 | sort`
+contexts=`/usr/local/bin/kubectl config get-contexts --no-headers | sed  -e' s/|/ /' -e 's/^ *//' -e 's/^* *//' | awk '{print $1}' | sort`
 size=`echo $contexts | wc -w`
 current=`/usr/local/bin/kubectl config current-context`
 index=0


### PR DESCRIPTION
The `kubectl` version 18 and probably also some versions before shows the output in that format:

```text
CURRENT   NAME                                     CLUSTER                            [...]
*         sandbox-admin                            sandbox                       
          test-1-admin                             test-west-1 
```
Instead of using  awk with `{print $2}` we first need to remove all leading whitespaces and the leading `*` plus all whitespaces to the next entry. Then we can use awk with `{print $1}` and get reliably the correct entry for the `NAME`.